### PR TITLE
Allow using subTLDs (like .co.uk, etc.) + cerbot interface

### DIFF
--- a/certbot-auth.sh
+++ b/certbot-auth.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+if [ -z "${CERTBOT_DOMAIN}" ]; then echo "This script needs CERTBOT_DOMAIN env"; exit 1; fi
+if [ -z "${CERTBOT_VALIDATION}" ]; then echo "This script needs CERTBOT_VALIDATION env"; exit 1; fi
+
+./dynect-hook.py deploy_challenge "${CERTBOT_DOMAIN}" "${CERTBOT_TOKEN}" "${CERTBOT_VALIDATION}"

--- a/certbot-cleanup.sh
+++ b/certbot-cleanup.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+if [ -z "${CERTBOT_DOMAIN}" ]; then echo "This script needs CERTBOT_DOMAIN env"; exit 1; fi
+if [ -z "${CERTBOT_VALIDATION}" ]; then echo "This script needs CERTBOT_VALIDATION env"; exit 1; fi
+
+./dynect-hook.py clean_challenge "${CERTBOT_DOMAIN}" "${CERTBOT_TOKEN}" "${CERTBOT_VALIDATION}"

--- a/dynect-hook.py
+++ b/dynect-hook.py
@@ -17,6 +17,8 @@ from dyn.tm.zones import Zone
 from dyn.tm.zones import Node
 from dyn.tm.records import ARecord
 
+from tld import get_tld
+
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.StreamHandler())
 logger.setLevel(logging.INFO)
@@ -43,8 +45,9 @@ def _has_dns_propagated(name, token):
 # https://dyn.readthedocs.org/en/latest/tm/zones.html
 def create_txt_record(args):
     domain, token = args[0], args[2]
-    zone_name = '.'.join(domain.split('.')[-2:])
-    node_name = "{0}.{1}".format('_acme-challenge', '.'.join(domain.split('.')[:-2]))
+    zone_name = get_tld('http://' + domain)
+    zone_parts = len(zone_name.split('.'))
+    node_name = '.'.join(['_acme-challenge'] + domain.split('.')[:-zone_parts])
     fqdn = "{0}.{1}".format(node_name, zone_name)
 
     zone = Zone(zone_name)
@@ -75,8 +78,9 @@ def delete_txt_record(args):
         logger.info(" + http_request() error in letsencrypt.sh?")
         return
 
-    zone_name = '.'.join(domain.split('.')[-2:])
-    node_name = "{0}.{1}".format('_acme-challenge', '.'.join(domain.split('.')[:-2]))
+    zone_name = get_tld('http://' + domain)
+    zone_parts = len(zone_name.split('.'))
+    node_name = '.'.join(['_acme-challenge'] + domain.split('.')[:-zone_parts])
     fqdn = "{0}.{1}".format(node_name, zone_name)
 
     zone = Zone(zone_name)


### PR DESCRIPTION
 Previously this hook didn't work with domains like `example.co.uk` cause it thought that zone in Dynect is `co.uk` - what is obviously wrong.

Now it looks for correct TLD and cuts correct info about TLDs.